### PR TITLE
Fix the move plugin and add move support

### DIFF
--- a/_test/plugin_siteexport_move.test.php
+++ b/_test/plugin_siteexport_move.test.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @group plugin_siteexport
+ * @group plugins
+ */
+class SiteexportMoveTest extends DokuWikiTest {
+    public function setup() {
+        $this->pluginsEnabled[] = 'siteexport';
+        $this->pluginsEnabled[] = 'move';
+        parent::setup();
+    }
+
+    public function test_move() {
+        /** @var $move helper_plugin_move_op */
+        $move = plugin_load('helper', 'move_op');
+        if (!$move) return; // disable the test when move is not installed
+        saveWikiText('pagetomove', '<toc>
+  * [[index|Index of the page]]
+    * [[foo:bar|Index of the sub namespace]]
+      * [[foo:index|Index of the sub/sub namespace]]
+    * [[.:foo:page|Page in the sub namespace]]
+</toc>', 'testcase created');
+        idx_addPage('pagetomove');
+        $this->assertTrue($move->movePage('pagetomove', 'test:movedpage'));
+        $this->assertEquals('<toc>
+  * [[:index|Index of the page]]
+    * [[foo:bar|Index of the sub namespace]]
+      * [[foo:index|Index of the sub/sub namespace]]
+    * [[foo:page|Page in the sub namespace]]
+</toc>',rawWiki('test:movedpage'));
+    }
+}

--- a/action/move.php
+++ b/action/move.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Site Export Plugin page move support for the move plugin
+ * 
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Michael Hamann <michael@content-space.de>
+ */
+
+// must be run within Dokuwiki
+if (!defined('DOKU_INC')) die('Not inside DokuWiki');
+
+class action_plugin_siteexport_move extends DokuWiki_Action_Plugin {
+    /**
+     * Register Plugin in DW
+     **/
+    public function register(Doku_Event_Handler $controller) {
+        $controller->register_hook('PLUGIN_MOVE_HANDLERS_REGISTER', 'BEFORE', $this, 'register_move_handler');
+    }
+
+    /**
+     * Register the handler for the move plugin.
+     */
+    public function register_move_handler(Doku_Event $event) {
+        $event->data['handlers']['siteexport_toc'] = array($this, 'move_handler');
+    }
+
+    /**
+     * Handle rewrites for the move plugin. Currently only the link/toc syntax is handled.
+     */
+    public function move_handler($match, $state, $pos, $pluginname, $handler) {
+        if ($state === DOKU_LEXER_SPECIAL) {
+            $handler->internallink($match, $state, $pos);
+            return '';
+        } else {
+            return $match;
+        }
+    }
+}

--- a/inc/filewriter.php
+++ b/inc/filewriter.php
@@ -11,7 +11,7 @@ class siteexport_zipfilewriter
     private $pdfGenerator = false;
     private $functions = null;
 
-    public function siteexport_zipfilewriter($functions = null)
+    public function __construct($functions = null)
     {
         $this->functions = $functions;
         if (class_exists('siteexport_pdfgenerator'))
@@ -231,4 +231,3 @@ class siteexport_zipfilewriter
     }
 }
 
-?>

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -9,7 +9,7 @@ class siteexport_functions extends DokuWiki_Plugin
     public $debug = null;
     public $settings = null;
 
-    public function siteexport_functions($init = true, $isAJAX = false)
+    public function __construct($init = true, $isAJAX = false)
     {
         if ($init)
         {
@@ -723,4 +723,3 @@ class siteexport_functions extends DokuWiki_Plugin
     }
 }
 
-?>

--- a/inc/javahelp.php
+++ b/inc/javahelp.php
@@ -17,7 +17,7 @@ class siteexport_javahelp
      * @param siteexport_functions $functions
      * @param siteexport_zipfilewriter $filewriter
      */
-    public function siteexport_javahelp($functions, $filewriter, $NS)
+    public function __construct($functions, $filewriter, $NS)
     {
         $this->NS = $NS;
         $this->functions = $functions;

--- a/inc/pdfgenerator.php
+++ b/inc/pdfgenerator.php
@@ -9,7 +9,7 @@ if (!empty($_REQUEST['pdfExport']) && intval($_REQUEST['pdfExport']) == 1 && fil
     {
         private $functions;
 
-        public function siteexport_pdfgenerator($functions = null)
+        public function __construct($functions = null)
         {
             $this->functions = $functions;
         }
@@ -189,4 +189,3 @@ if (!empty($_REQUEST['pdfExport']) && intval($_REQUEST['pdfExport']) == 1 && fil
         }
     }
 }
-?>

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -36,7 +36,7 @@ class settings_plugin_siteexport_settings extends DokuWiki_Plugin
     /**
      * @param siteexport_functions $functions
      */
-    function settings_plugin_siteexport_settings($functions) {
+    function __construct($functions) {
         global $ID, $conf;
         
         $functions->debug->setDebugFile($this->getConf('debugFile'));
@@ -99,4 +99,3 @@ class settings_plugin_siteexport_settings extends DokuWiki_Plugin
     }
 }
 
-?>

--- a/inc/toc.php
+++ b/inc/toc.php
@@ -9,7 +9,7 @@ class siteexport_toc
     private $NS = null;
     public $translation = null;
     
-    public function siteexport_toc($functions, $NS)
+    public function __construct($functions, $NS)
     {
         $this->emptyNSToc = !empty($_REQUEST['emptyTocElem']);
         $this->functions = $functions;
@@ -485,4 +485,3 @@ class siteexport_toc
     }
 }
 
-?>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# we need additional plugin(s) for testing
+https://github.com/michitux/dokuwiki-plugin-move.git lib/plugins/move


### PR DESCRIPTION
This adds support for the move plugin and in fact fixes the link rewriting of the move plugin as previously all links were "captured" by the siteexport plugin and no longer visible for the move plugin and therefore could not be handled anymore (see also michitux/dokuwiki-plugin-move#81). I've also added a test case.

In order to get the test running on my system (PHP 7.0) I also had to rename some constructors to the new PHP standard (`__construct` instead of class name). Further, I removed the `?>` at the end of the changes files in order to prevent printing spaces. I hope the travis support works also for the new test with the move plugin (I added the move plugin as a requirement for the tests).